### PR TITLE
更新 dns 记录的时候应该保留原有的 ttl

### DIFF
--- a/lib/dnsUpdater.js
+++ b/lib/dnsUpdater.js
@@ -179,8 +179,6 @@ DNSUpdater.prototype.updateRecordValue = function () {
                 //export to global
                 self.params.record_value = result;
                 self.params.value = result;
-                
-                
                 callback(null, true);
             } else {
                 callback(null, false);


### PR DESCRIPTION
在 dnspod 内手工修改默认的 ttl 600 为 120后—— dnspod-ddns 会在 ip 变动后，更新 ip 并将 ttl 恢复为默认的 600。

更大的 ttl 将导致新记录的生效更慢。
此 pull request 手工测试可以维持旧的 ttl。
没有看到测试脚本，就不写了。
